### PR TITLE
🐛 Handle correctly "alerte renforcée" state

### DIFF
--- a/custom_components/vigieau/__init__.py
+++ b/custom_components/vigieau/__init__.py
@@ -222,7 +222,7 @@ class AlertLevelEntity(CoordinatorEntity, SensorEntity):
             "alerte": "mdi:water-alert",
             "alerte_renforcee": "mdi:water-remove",
             "crise": "mdi:water-off",
-        }[self._attr_native_value.lower()]
+        }[self._attr_native_value.lower().replace(' ', '_')]
 
         self.enrich_attributes(self.coordinator.data, "cheminFichier", "source")
         self.enrich_attributes(


### PR DESCRIPTION
It's unclear whether status are expected to respect the propluvia statuses or not but at least now we handle both

Change-Id: I8d0a5c28ce07ea3331b096fb8fc58ede76af009a