### PR TITLE
🐛 Always include lat/long in request to vigieau api

### DIFF
--- a/custom_components/vigieau/__init__.py
+++ b/custom_components/vigieau/__init__.py
@@ -144,10 +144,11 @@ class VigieauAPICoordinator(DataUpdateCoordinator):
             _LOGGER.debug("Starting collecting data")
 
             city_code = self.config[CONF_INSEE_CODE]
+            lat = self.config[CONF_LATITUDE]
+            long = self.config[CONF_LONGITUDE]
 
             # TODO(kamaradclimber): there 4 supported profils: particulier, entreprise, collectivite and exploitation
-            url = f"{BASE_URL}/reglementation?commune={city_code}&profil=particulier"
-            # url = f"{BASE_URL}/reglementation?lat={self.lat}&lon={self.lon}&commune={city_code}&profil=particulier"
+            url = f"{BASE_URL}/reglementation?lat={lat}&lon={long}&commune={city_code}&profil=particulier"
             _LOGGER.debug(f"Requesting restrictions from {url}")
             r = await self._async_client.get(url)
             if (

--- a/custom_components/vigieau/config_flow.py
+++ b/custom_components/vigieau/config_flow.py
@@ -139,7 +139,6 @@ class SetupConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             }
         )
         errors = {}
-        _LOGGER.debug("in async_map_select !!")
         if user_input is not None:
             try:
                 city_infos = await get_insee_code_fromcoord(
@@ -152,6 +151,8 @@ class SetupConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             if not errors:
                 self.data[CONF_INSEE_CODE] = city_infos[0]
                 self.data[CONF_CITY] = city_infos[1]
+                # TODO(kamaradclimber): it's not clear whether we should take lat/long from user input
+                # or from address api results.
                 self.data[CONF_LATITUDE] = city_infos[2]
                 self.data[CONF_LONGITUDE] = city_infos[3]
                 self.data[DEVICE_ID_KEY] = city_infos[0]


### PR DESCRIPTION
Goal is to make sure it works as well for cases where the api expects lat/long (which it not always does).

Fixes #37