### PR TITLE
Stabilize entity unique ids

### DIFF
--- a/custom_components/vigieau/config_flow.py
+++ b/custom_components/vigieau/config_flow.py
@@ -81,7 +81,7 @@ def _build_place_key(city) -> str:
 
 
 class SetupConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
-    VERSION = 3
+    VERSION = 4
 
     def __init__(self):
         """Initialize"""


### PR DESCRIPTION
Entity were broken (duplicated) if we changed their name. Now their id is based on the key (I think it was the original intent and somehow went buggy)