### PR TITLE
Match "usage" and "thematique" fields together

### DIFF
--- a/custom_components/vigieau/__init__.py
+++ b/custom_components/vigieau/__init__.py
@@ -173,7 +173,7 @@ class VigieauAPICoordinator(DataUpdateCoordinator):
                     for matcher in sensor.matchers:
                         if re.search(
                             matcher,
-                            usage["usage"],
+                            usage["usage"] + "|" + usage['thematique'],
                             re.IGNORECASE,
                         ):
                             found = True
@@ -326,7 +326,8 @@ class UsageRestrictionEntity(CoordinatorEntity, SensorEntity):
         self._attr_name = str(self._config.name)
         for usage in self.coordinator.data["usages"]:
             for matcher in self._config.matchers:
-                if re.search(matcher, usage["usage"], re.IGNORECASE):
+                fully_qualified_usage = usage["usage"] + "|" + usage['thematique']
+                if re.search(matcher, fully_qualified_usage, re.IGNORECASE):
                     self._attr_state_attributes = self._attr_state_attributes or {}
                     restriction = usage.get("niveauRestriction", usage.get("erreur"))
                     if restriction is None:

--- a/custom_components/vigieau/tests/test_regexp.py
+++ b/custom_components/vigieau/tests/test_regexp.py
@@ -30,7 +30,7 @@ class TestRegexp(unittest.TestCase):
                     for matcher in sensor.matchers:
                         if re.search(
                             matcher,
-                            restriction["usage"],
+                            restriction["usage"] + "|" + restriction['thematique'],
                             re.IGNORECASE,
                         ):
                             found = True


### PR DESCRIPTION
This is a hack to deal with the "Autres usages" cases that are not specific enough by themselves.
This patch allows to catch those cases by matching "Autres usages | Travaux en canaux" for instance.

This will fix tests that are currently failing because of such a case