### PR TITLE
✨ Follow HA location change

### DIFF
--- a/custom_components/vigieau/__init__.py
+++ b/custom_components/vigieau/__init__.py
@@ -36,6 +36,7 @@ from .const import (
     CONF_INSEE_CODE,
     CONF_LOCATION_MODE,
     CONF_ZONE_TYPE,
+    CONF_FOLLOW_HA_COORDS,
     DEVICE_ID_KEY,
     DOMAIN,
     HA_COORD,
@@ -50,6 +51,7 @@ _LOGGER = logging.getLogger(__name__)
 MIGRATED_FROM_VERSION_1 = "migrated_from_version_1"
 MIGRATED_FROM_VERSION_3 = "migrated_from_version_3"
 MIGRATED_FROM_VERSION_5 = "migrated_from_version_5"
+MIGRATED_FROM_VERSION_6 = "migrated_from_version_6"
 
 
 async def async_migrate_entry(hass, config_entry: ConfigEntry):
@@ -95,6 +97,12 @@ async def async_migrate_entry(hass, config_entry: ConfigEntry):
         new = {**config_entry.data}
         new[MIGRATED_FROM_VERSION_5] = True
         hass.config_entries.async_update_entry(config_entry, data=new, version=6)
+    if config_entry.version == 6:
+        _LOGGER.warn("config entry version is 6, migrating to version 7")
+        new = {**config_entry.data}
+        new[CONF_FOLLOW_HA_COORDS] = False
+        new[MIGRATED_FROM_VERSION_6] = True
+        hass.config_entries.async_update_entry(config_entry, data=new, version=7)
 
     return True
 

--- a/custom_components/vigieau/config_flow.py
+++ b/custom_components/vigieau/config_flow.py
@@ -15,6 +15,7 @@ from .const import (
     CONF_CITY,
     CONF_CODE_POSTAL,
     CONF_INSEE_CODE,
+    CONF_FOLLOW_HA_COORDS,
     CONF_LOCATION_MAP,
     CONF_LOCATION_MODE,
     CONF_ZONE_TYPE,
@@ -86,7 +87,7 @@ def _build_place_key(city) -> str:
 
 
 class SetupConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
-    VERSION = 6
+    VERSION = 7
 
     def __init__(self):
         """Initialize"""
@@ -123,6 +124,7 @@ class SetupConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                     self.data[CONF_LATITUDE] = city_infos[2]
                     self.data[CONF_LONGITUDE] = city_infos[3]
                     self.data[DEVICE_ID_KEY] = city_infos[0]
+                    self.data[CONF_FOLLOW_HA_COORDS] = True
                     return await self.async_step_location(user_input=self.data)
             elif user_input[CONF_LOCATION_MODE] == ZIP_CODE:
                 self.data = user_input
@@ -162,6 +164,7 @@ class SetupConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 self.data[CONF_LATITUDE] = city_infos[2]
                 self.data[CONF_LONGITUDE] = city_infos[3]
                 self.data[DEVICE_ID_KEY] = city_infos[0]
+                self.data[CONF_FOLLOW_HA_COORDS] = False
                 return await self.async_step_location(user_input=self.data)
         return self._show_setup_form("map_select", None, COORD_SCHEMA, errors)
 
@@ -224,4 +227,5 @@ class SetupConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         self.data[CONF_LONGITUDE] = city_infos[2]
         self.data[CONF_LATITUDE] = city_infos[3]
         self.data[DEVICE_ID_KEY] = city_infos[0]
+        self.data[CONF_FOLLOW_HA_COORDS] = False
         return await self.async_step_location(self.data)

--- a/custom_components/vigieau/const.py
+++ b/custom_components/vigieau/const.py
@@ -9,6 +9,7 @@ CONF_INSEE_CODE = "INSEE"
 CONF_LOCATION_MAP = "location_map"
 CONF_LOCATION_MODE = "location_mode"
 CONF_ZONE_TYPE = "zone_type"
+CONF_FOLLOW_HA_COORDS = "follow_ha_coords"
 
 DEVICE_ID_KEY = "device_id"
 DOMAIN = "vigieau"


### PR DESCRIPTION
When HA instance location changes, the next vigieau refresh will detect
    it and adapt.
    
Technically this is made by introducing a storage with all data that
    used to be in config (which still are in config but it seems hard to
    update this outside of the HA startup phase)
    
Downside: it does not yet update the entity names or the device name
    which makes it a bit weird.
    
Fix #48