### PR TITLE
feat: add binary sensors, dynamic attributes, and improve time-based …

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,11 @@ deps/
 home-assistant.log*
 home-assistant_v2.db
 *.pyc
+
+# virtualenv
+lib/
+bin/
+include/
+pyvenv.cfg
+.cache/
+release.sh

--- a/README.md
+++ b/README.md
@@ -43,3 +43,26 @@ This integration uses a geocoding API to get the city code from INSEE (used as a
 
 A workaround can be used by setting the `VIGIEAU_FORCED_INSEE_CITY_CODE` environment variable with the city code as value.
 ⚠ Value of city code is not necessarily city "postal code". You can find it easily of wikipedia under the name [code commune](https://fr.wikipedia.org/wiki/Code_officiel_g%C3%A9ographique#Code_commune).
+
+## Sensors
+
+Two sensors are created for each water usage category:
+
+| Type | Description | Diagnostic category | Enabled by default |
+|---|---|---|---|
+| `sensor` | Textual restriction level (native value: "Aucune restriction", "Interdiction", "Interdiction sur plage horaire", etc.) | No | No |
+| `binary_sensor` | `on` = allowed, `off` = restricted | Yes | Yes for fountains, vegetable gardens, lawns, car wash, swimming pools |
+
+### Attributes
+
+All sensors expose these additional attributes for automations:
+
+| Attribute | Description |
+|---|---|
+| `currently_restricted` | `true` if a restriction is currently active |
+| `restriction` | Textual restriction level (same as string sensor native value) |
+| `next_restriction_start` | (time-based restrictions only) Next restriction start time (ISO format) |
+| `next_restriction_end` | (time-based restrictions only) Next restriction end time (ISO format) |
+| `Categorie: <name>` | Exact API description for that usage |
+| `<name> (details)` | Additional usage details from the API |
+| `heureDebut` / `heureFin` | (if unambiguous) Restriction time window |

--- a/custom_components/vigieau/__init__.py
+++ b/custom_components/vigieau/__init__.py
@@ -3,7 +3,7 @@ import re
 import json
 import urllib.parse
 import logging
-from datetime import timedelta, datetime
+from datetime import timedelta, time as dt_time
 from dateutil import tz
 from itertools import dropwhile, takewhile
 from typing import Any, Dict, Optional, Tuple
@@ -11,6 +11,7 @@ from zoneinfo import ZoneInfo
 import aiohttp
 
 from homeassistant.components.sensor import RestoreSensor, SensorEntity
+from homeassistant.components.binary_sensor import BinarySensorEntity
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import (
     CONF_LATITUDE,
@@ -28,6 +29,8 @@ from homeassistant.helpers.update_coordinator import (
     UpdateFailed,
 )
 from homeassistant.helpers.storage import Store
+from homeassistant.helpers.event import async_track_point_in_time
+from homeassistant.util import dt as dt_util
 
 from .api import VigieauAPI, VigieauAPIError
 from .config_flow import get_insee_code_fromcoord, SetupConfigFlow
@@ -125,8 +128,10 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             hass, dict(entry.data), entry.entry_id
         )
 
-    # will make sure async_setup_entry from sensor.py is called
-    await hass.config_entries.async_forward_entry_setups(entry, [Platform.SENSOR])
+    # will make sure async_setup_entry from sensor.py and binary_sensor.py are called
+    await hass.config_entries.async_forward_entry_setups(
+        entry, [Platform.SENSOR, Platform.BINARY_SENSOR]
+    )
 
     # subscribe to config updates
     entry.async_on_unload(entry.add_update_listener(update_entry))
@@ -148,7 +153,7 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """This method is called to clean all sensors before re-adding them"""
     _LOGGER.debug("async_unload_entry method called")
     unload_ok = await hass.config_entries.async_unload_platforms(
-        entry, [Platform.SENSOR]
+        entry, [Platform.SENSOR, Platform.BINARY_SENSOR]
     )
     if unload_ok:
         hass.data[DOMAIN].pop(entry.entry_id)
@@ -283,6 +288,23 @@ def zone_type_to_str(zone_type: str) -> str:
     return names.get(zone_type, "Zone inconnue")
 
 
+def _parse_time_str(time_str: str) -> Optional[dt_time]:
+    """Parse time string from API (HH:MM or HHhMM) into datetime.time"""
+    if not time_str:
+        return None
+    time_str = time_str.strip()
+    match = re.match(r'(\d{1,2}):(\d{2})', time_str)
+    if match:
+        return dt_time(int(match.group(1)), int(match.group(2)))
+    match = re.match(r'(\d{1,2})h(\d{2})', time_str)
+    if match:
+        return dt_time(int(match.group(1)), int(match.group(2)))
+    match = re.match(r'(\d{1,2})h\s*$', time_str)
+    if match:
+        return dt_time(int(match.group(1)), 0)
+    return None
+
+
 class AlertLevelEntity(CoordinatorEntity, SensorEntity):
     """Expose the alert level for the location"""
 
@@ -391,48 +413,16 @@ class AlertLevelEntity(CoordinatorEntity, SensorEntity):
         return self._attr_state_attributes
 
 
-class UsageRestrictionEntity(CoordinatorEntity, SensorEntity):
-    """Expose a restriction for a given usage"""
+class RestrictionMixin:
+    """Shared logic for restriction entities (string sensors and binary sensors)"""
 
-    entity_description: VigieEauSensorEntityDescription
-
-    def __init__(
-        self,
-        coordinator: VigieauAPICoordinator,
-        hass: HomeAssistant,
-        usage_id: str,
-        config_entry: ConfigEntry,
-        description: VigieEauSensorEntityDescription,
-    ):
-        super().__init__(coordinator)
-        self.hass = hass
-        self._config_entry = config_entry
-        # naming the attribute very early before it's updated by first api response is a hack
-        # to make sure we have a decent entity_id selected by home assistant
-        self._attr_name = (
-            f"{description.name}_restrictions_{config_entry.data.get(CONF_CITY)}"
-        )
-        self._attr_native_value = None
-        self._attr_state_attributes = None
-        self._attr_entity_category = EntityCategory.DIAGNOSTIC
-        self._config = description
-        if MIGRATED_FROM_VERSION_1 in config_entry.data:
-            self._attr_unique_id = f"sensor-vigieau-{self._config.key}"
-        elif MIGRATED_FROM_VERSION_3 in config_entry.data:
-            self._attr_unique_id = f"sensor-vigieau-{self._attr_name}-{config_entry.data.get(CONF_INSEE_CODE)}-{config_entry.data.get(CONF_LATITUDE)}-{config_entry.data.get(CONF_LONGITUDE)}"
-        elif MIGRATED_FROM_VERSION_5 in config_entry.data:
-            self._attr_unique_id = f"sensor-vigieau-{self._config.key}-{config_entry.data.get(CONF_INSEE_CODE)}-{config_entry.data.get(CONF_LATITUDE)}-{config_entry.data.get(CONF_LONGITUDE)}"
-        else:
-            self._attr_unique_id = f"sensor-vigieau-{self._config.key}-{config_entry.data.get(CONF_INSEE_CODE)}-{config_entry.data.get(CONF_LATITUDE)}-{config_entry.data.get(CONF_LONGITUDE)}-{config_entry.data.get(CONF_ZONE_TYPE)}"
-        self._attr_device_info = self.build_device()
+    @property
+    def state_attributes(self):
+        return self._attr_state_attributes
 
     def build_device(self) -> DeviceInfo:
         data = self._config_entry.data
-        if self.coordinator.location is not None:
-            data = self.coordinator.location()
         return DeviceInfo(
-            name=f"{NAME} {data.get(CONF_CITY)} {zone_type_to_str(data.get(CONF_ZONE_TYPE))}",
-            entry_type=DeviceEntryType.SERVICE,
             identifiers={
                 (
                     DOMAIN,
@@ -448,64 +438,6 @@ class UsageRestrictionEntity(CoordinatorEntity, SensorEntity):
             self._attr_state_attributes = self._attr_state_attributes or {}
             self._attr_state_attributes[key_target] = usage[key_source]
 
-    @property
-    def icon(self):
-        return self._config.icon
-
-    @callback
-    def _handle_coordinator_update(self) -> None:
-        _LOGGER.debug(f"Receiving an update for {self.unique_id} sensor")
-        if not self.coordinator.last_update_success:
-            _LOGGER.debug(
-                "Last coordinator failed, assuming state has not changed")
-            return
-        self._attr_device_info = self.build_device()
-        self._attr_state_attributes = self._attr_state_attributes or {}
-        self._restrictions = []
-        self._time_restrictions = {}
-        self._attr_name = str(self._config.name)
-        for usage in self.coordinator.data["usages"]:
-            if self._config.match(usage):
-                self._attr_state_attributes = self._attr_state_attributes or {}
-                restriction = usage.get("description")
-                if restriction is None:
-                    raise UpdateFailed(
-                        "Restriction level is not specified"
-                    )
-                self._attr_state_attributes[
-                    f"Categorie: {usage['nom']}"
-                ] = restriction
-                self._restrictions.append(restriction)
-
-                self.enrich_attributes(
-                    usage, "details", f"{usage['nom']} (details)"
-                )
-                if "heureFin" in usage and "heureDebut" in usage:
-                    self._time_restrictions[usage["nom"]] = [
-                        usage["heureDebut"],
-                        usage["heureFin"],
-                    ]
-
-        # we only want to add those attributes if they are not ambiguous
-        if len(set([repr(r) for r in self._time_restrictions.values()])) == 1:
-            restrictions = list(self._time_restrictions.values())[0]
-            self._attr_state_attributes["heureDebut"] = restrictions[0]
-            self._attr_state_attributes["heureFin"] = restrictions[1]
-        elif len(self._time_restrictions) > 0:
-            _LOGGER.debug(
-                f"There are {len(self._time_restrictions)} usage with time restrictions for this sensor, exposing info per usage"
-            )
-            for name in self._time_restrictions:
-                self._attr_state_attributes[
-                    f"{name} (heureDebut)"
-                ] = self._time_restrictions[name][0]
-                self._attr_state_attributes[
-                    f"{name} (heureFin)"
-                ] = self._time_restrictions[name][1]
-
-        self._attr_native_value = self.compute_native_value()
-        self.async_write_ha_state()
-
     def compute_native_value(self) -> Optional[str]:
         """This method extract the most relevant restriction level to display as aggregate"""
 
@@ -516,10 +448,33 @@ class UsageRestrictionEntity(CoordinatorEntity, SensorEntity):
                     return True
             return False
 
+        TIME_PATTERNS = [r"interdiction sur plage horaire", r"interdiction.*\d+\s*h"]
+
+        def has_time_based_interdiction():
+            for pattern in TIME_PATTERNS:
+                r = re.compile(pattern, re.IGNORECASE)
+                for restriction in self._restrictions:
+                    if r.search(restriction):
+                        return True
+            return False
+
+        def has_non_time_interdiction():
+            r_inter = re.compile(r"interdiction", re.IGNORECASE)
+            r_time = re.compile("|".join(TIME_PATTERNS), re.IGNORECASE)
+            for restriction in self._restrictions:
+                if r_inter.search(restriction) and not r_time.search(restriction):
+                    return True
+            return False
+
+        self._native_is_time_based = False
+
         if len(self._restrictions) == 0:
             return "Aucune restriction"
-        if any_restriction_match("interdiction sur plage horaire"):
+
+        if not has_non_time_interdiction() and has_time_based_interdiction():
+            self._native_is_time_based = True
             return "Interdiction sur plage horaire"
+
         if any_restriction_match("interdi.*sauf"):
             return "Interdiction sauf exception"
         if any_restriction_match("à l’exception"):
@@ -560,9 +515,309 @@ class UsageRestrictionEntity(CoordinatorEntity, SensorEntity):
         )
         _LOGGER.warning(
             f"The following restriction are hard to interpret by this integration, please report an issue with: {report_data}"
-                    )
+        )
         return None
 
+    def _is_time_based(self) -> bool:
+        return self._native_is_time_based
+
+    def _extract_time_range_from_descriptions(self):
+        for restriction in self._restrictions:
+            match = re.search(r"(\d{1,2})\s*h.*?(\d{1,2})\s*h", restriction)
+            if match:
+                start_str = f"{match.group(1)}h"
+                end_str = f"{match.group(2)}h"
+                start_time = _parse_time_str(start_str)
+                end_time = _parse_time_str(end_str)
+                if start_time is not None and end_time is not None:
+                    _LOGGER.debug(
+                        f"Extracted time range {start_time}-{end_time} from description: {restriction}"
+                    )
+                    return (start_time, end_time)
+        return None
+
+    def _get_effective_time_ranges(self):
+        ranges = []
+        for name, (start_str, end_str) in self._time_restrictions.items():
+            start = _parse_time_str(start_str)
+            end = _parse_time_str(end_str)
+            if start is not None and end is not None:
+                ranges.append((start, end))
+        if not ranges and self._extracted_time_range is not None:
+            ranges.append(self._extracted_time_range)
+        return ranges
+
+    def _is_currently_restricted(self, now_time=None):
+        if now_time is None:
+            now_time = dt_util.now().time()
+        for start_time, end_time in self._get_effective_time_ranges():
+            if start_time <= end_time:
+                if start_time <= now_time < end_time:
+                    return True
+            else:
+                if now_time >= start_time or now_time < end_time:
+                    return True
+        return False
+
+    def _update_dynamic_attributes(self):
+        R = self._attr_state_attributes.get("restriction") if self._attr_state_attributes else None
+
+        if self._native_is_time_based:
+            now_time = dt_util.now().time()
+            is_restricted = self._is_currently_restricted(now_time)
+            time_ranges = self._get_effective_time_ranges()
+            _LOGGER.debug(f"Dynamic attr for {self.unique_id}: time_based=True, now_time={now_time}, ranges={time_ranges}, is_restricted={is_restricted}, R={R}")
+        elif R in ("Aucune restriction", "Autorisé sauf exception", "Sensibilisation"):
+            is_restricted = False
+        else:
+            is_restricted = True
+
+        self._attr_state_attributes["currently_restricted"] = is_restricted
+
+        if self._native_is_time_based:
+            now = dt_util.now()
+            now_time = now.time()
+            ranges = self._get_effective_time_ranges()
+
+            if ranges:
+                start_time, end_time = ranges[0]
+                start_dt = now.replace(hour=start_time.hour, minute=start_time.minute, second=0, microsecond=0)
+                end_dt = now.replace(hour=end_time.hour, minute=end_time.minute, second=0, microsecond=0)
+
+                if start_dt <= now:
+                    start_dt += timedelta(days=1)
+                if end_dt <= now:
+                    end_dt += timedelta(days=1)
+
+                if start_time > end_time:
+                    if is_restricted:
+                        next_autorisation = end_dt
+                        next_coupure = start_dt
+                    else:
+                        next_coupure = start_dt
+                        next_autorisation = end_dt
+                else:
+                    if is_restricted:
+                        next_autorisation = end_dt
+                        next_coupure = start_dt
+                    else:
+                        next_coupure = start_dt
+                        next_autorisation = end_dt
+
+                self._attr_state_attributes["next_restriction_start"] = next_coupure.isoformat()
+                self._attr_state_attributes["next_restriction_end"] = next_autorisation.isoformat()
+        else:
+            self._attr_state_attributes.pop("next_restriction_start", None)
+            self._attr_state_attributes.pop("next_restriction_end", None)
+
+    def _cancel_timer(self):
+        if self._unsub_timer is not None:
+            _LOGGER.debug(f"Cancelling timer for {getattr(self, 'unique_id', 'unknown')}")
+            self._unsub_timer()
+            self._unsub_timer = None
+
+    def _schedule_next_time_update(self):
+        now = dt_util.now()
+        now_time = now.time()
+        next_boundary = None
+        ranges = self._get_effective_time_ranges()
+
+        _LOGGER.debug(f"Schedule compute for {self.unique_id}: now={now.isoformat()}, now_time={now_time}, ranges={ranges}, time_restrictions={getattr(self, '_time_restrictions', {})}, extracted_range={getattr(self, '_extracted_time_range', None)}")
+
+        for start_time, end_time in ranges:
+            start_dt = now.replace(hour=start_time.hour, minute=start_time.minute, second=0, microsecond=0)
+            end_dt = now.replace(hour=end_time.hour, minute=end_time.minute, second=0, microsecond=0)
+
+            _LOGGER.debug(f"Range raw: start_time={start_time}, end_time={end_time}, start_dt={start_dt}, end_dt={end_dt}")
+
+            if start_dt <= now:
+                start_dt += timedelta(days=1)
+                _LOGGER.debug(f"start_dt adjusted to {start_dt} (was <= now)")
+            if end_dt <= now:
+                end_dt += timedelta(days=1)
+                _LOGGER.debug(f"end_dt adjusted to {end_dt} (was <= now)")
+
+            if start_time > end_time:
+                if now_time >= start_time or now_time < end_time:
+                    candidate = end_dt
+                else:
+                    candidate = start_dt
+            else:
+                candidate = min(start_dt, end_dt)
+
+            _LOGGER.debug(f"Candidate for range {start_time}-{end_time}: {candidate.isoformat()}, start_dt={start_dt.isoformat()}, end_dt={end_dt.isoformat()}")
+
+            if next_boundary is None or candidate < next_boundary:
+                next_boundary = candidate
+
+        if next_boundary is not None:
+            _LOGGER.debug(f"Scheduling next attribute update for {self.unique_id} at {next_boundary.isoformat()} (tzinfo={next_boundary.tzinfo})")
+            self._unsub_timer = async_track_point_in_time(
+                self.hass,
+                self._time_boundary_reached,
+                next_boundary,
+            )
+        else:
+            _LOGGER.debug(f"No next boundary to schedule for {self.unique_id}")
+
+    @callback
+    def _time_boundary_reached(self, now):
+        _LOGGER.debug(f"Time boundary reached for {self.unique_id}, updating attributes. event_time={now}, system_time={dt_util.now().isoformat()}, timer_active={self._unsub_timer is not None}")
+        self._update_dynamic_attributes()
+        self._schedule_next_time_update()
+        self.async_write_ha_state()
+
+    async def async_will_remove_from_hass(self):
+        self._cancel_timer()
+        await super().async_will_remove_from_hass()
+
+    @callback
+    def _handle_coordinator_update(self) -> None:
+        _LOGGER.debug(f"Receiving an update for {self.unique_id} sensor (timer_active={self._unsub_timer is not None})")
+        if not self.coordinator.last_update_success:
+            _LOGGER.debug(
+                "Last coordinator failed, assuming state has not changed")
+            return
+        self._cancel_timer()
+        self._attr_device_info = self.build_device()
+        self._attr_state_attributes = self._attr_state_attributes or {}
+        self._restrictions = []
+        self._time_restrictions = {}
+        self._extracted_time_range = None
+        self._attr_name = str(self._config.name)
+        for usage in self.coordinator.data["usages"]:
+            if self._config.match(usage):
+                self._attr_state_attributes = self._attr_state_attributes or {}
+                restriction = usage.get("description")
+                if restriction is None:
+                    raise UpdateFailed(
+                        "Restriction level is not specified"
+                    )
+                self._attr_state_attributes[
+                    f"Categorie: {usage['nom']}"
+                ] = restriction
+                self._restrictions.append(restriction)
+
+                self.enrich_attributes(
+                    usage, "details", f"{usage['nom']} (details)"
+                )
+                if "heureFin" in usage and "heureDebut" in usage:
+                    self._time_restrictions[usage["nom"]] = [
+                        usage["heureDebut"],
+                        usage["heureFin"],
+                    ]
+
+        if len(set([repr(r) for r in self._time_restrictions.values()])) == 1:
+            restrictions = list(self._time_restrictions.values())[0]
+            self._attr_state_attributes["heureDebut"] = restrictions[0]
+            self._attr_state_attributes["heureFin"] = restrictions[1]
+        elif len(self._time_restrictions) > 0:
+            _LOGGER.debug(
+                f"There are {len(self._time_restrictions)} usage with time restrictions for this sensor, exposing info per usage"
+            )
+            for name in self._time_restrictions:
+                self._attr_state_attributes[
+                    f"{name} (heureDebut)"
+                ] = self._time_restrictions[name][0]
+                self._attr_state_attributes[
+                    f"{name} (heureFin)"
+                ] = self._time_restrictions[name][1]
+
+        if not self._time_restrictions:
+            self._extracted_time_range = self._extract_time_range_from_descriptions()
+
+        native_value = self.compute_native_value()
+        self._attr_state_attributes["restriction"] = native_value
+        self._update_dynamic_attributes()
+        self._on_restrictions_updated(native_value)
+        _LOGGER.debug(f"Coordinator update for {self.unique_id}: is_time_based={self._is_time_based()}, _native_is_time_based={self._native_is_time_based}, _time_restrictions={self._time_restrictions}, extracted_range={self._extracted_time_range}")
+        if self._is_time_based():
+            self._schedule_next_time_update()
+        self.async_write_ha_state()
+
+    def _on_restrictions_updated(self, native_value: str):
+        """Hook for subclasses to update entity state after restriction data changes"""
+        pass
+
+
+class UsageRestrictionEntity(RestrictionMixin, CoordinatorEntity, SensorEntity):
+    """Expose a restriction for a given usage as a string sensor"""
+
+    entity_description: VigieEauSensorEntityDescription
+
+    def __init__(
+        self,
+        coordinator: VigieauAPICoordinator,
+        hass: HomeAssistant,
+        config_entry: ConfigEntry,
+        description: VigieEauSensorEntityDescription,
+    ):
+        super().__init__(coordinator)
+        self.hass = hass
+        self._config_entry = config_entry
+        self._attr_name = (
+            f"{description.name}_restrictions_{config_entry.data.get(CONF_CITY)}"
+        )
+        self._attr_native_value = None
+        self._attr_state_attributes = None
+        self._attr_entity_registry_enabled_default = False
+        self._config = description
+        self._unsub_timer = None
+        self._native_is_time_based = False
+        self._extracted_time_range = None
+        if MIGRATED_FROM_VERSION_1 in config_entry.data:
+            self._attr_unique_id = f"sensor-vigieau-{self._config.key}"
+        elif MIGRATED_FROM_VERSION_3 in config_entry.data:
+            self._attr_unique_id = f"sensor-vigieau-{self._attr_name}-{config_entry.data.get(CONF_INSEE_CODE)}-{config_entry.data.get(CONF_LATITUDE)}-{config_entry.data.get(CONF_LONGITUDE)}"
+        elif MIGRATED_FROM_VERSION_5 in config_entry.data:
+            self._attr_unique_id = f"sensor-vigieau-{self._config.key}-{config_entry.data.get(CONF_INSEE_CODE)}-{config_entry.data.get(CONF_LATITUDE)}-{config_entry.data.get(CONF_LONGITUDE)}"
+        else:
+            self._attr_unique_id = f"sensor-vigieau-{self._config.key}-{config_entry.data.get(CONF_INSEE_CODE)}-{config_entry.data.get(CONF_LATITUDE)}-{config_entry.data.get(CONF_LONGITUDE)}-{config_entry.data.get(CONF_ZONE_TYPE)}"
+        self._attr_device_info = self.build_device()
+
     @property
-    def state_attributes(self):
-        return self._attr_state_attributes
+    def icon(self):
+        return self._config.icon
+
+    def _on_restrictions_updated(self, native_value: str):
+        self._attr_native_value = native_value
+
+
+class UsageRestrictionBinaryEntity(RestrictionMixin, CoordinatorEntity, BinarySensorEntity):
+    """Expose a restriction for a given usage as a binary sensor (on=restricted)"""
+
+    entity_description: VigieEauSensorEntityDescription
+
+    def __init__(
+        self,
+        coordinator: VigieauAPICoordinator,
+        hass: HomeAssistant,
+        config_entry: ConfigEntry,
+        description: VigieEauSensorEntityDescription,
+    ):
+        super().__init__(coordinator)
+        self.hass = hass
+        self._config_entry = config_entry
+        self._attr_name = (
+            f"{description.name}_binary_{config_entry.data.get(CONF_CITY)}"
+        )
+        self._attr_is_on = False
+        self._attr_state_attributes = None
+        self._attr_entity_category = EntityCategory.DIAGNOSTIC
+        self._attr_entity_registry_enabled_default = description.commonly_used
+        self._config = description
+        self._unsub_timer = None
+        self._native_is_time_based = False
+        self._extracted_time_range = None
+        self._attr_unique_id = f"binary_sensor-vigieau-{self._config.key}-{config_entry.data.get(CONF_INSEE_CODE)}-{config_entry.data.get(CONF_LATITUDE)}-{config_entry.data.get(CONF_LONGITUDE)}-{config_entry.data.get(CONF_ZONE_TYPE)}"
+        self._attr_device_info = self.build_device()
+
+    @property
+    def is_on(self):
+        return not self._attr_state_attributes.get("currently_restricted", True) if self._attr_state_attributes else True
+
+    @property
+    def icon(self):
+        if self._attr_state_attributes and self._attr_state_attributes.get("currently_restricted"):
+            return "mdi:water-off"
+        return "mdi:water-check"

--- a/custom_components/vigieau/binary_sensor.py
+++ b/custom_components/vigieau/binary_sensor.py
@@ -5,8 +5,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from . import (
-    AlertLevelEntity,
-    UsageRestrictionEntity,
+    UsageRestrictionBinaryEntity,
 )
 from .const import DOMAIN, SENSOR_DEFINITIONS
 
@@ -18,13 +17,10 @@ async def async_setup_entry(
 ) -> None:
     vigieau_coordinator = hass.data[DOMAIN][entry.entry_id]["vigieau_coordinator"]
     sensors = [
-        UsageRestrictionEntity(
+        UsageRestrictionBinaryEntity(
             vigieau_coordinator, hass, entry, sensor_description
         )
         for sensor_description in SENSOR_DEFINITIONS
     ]
-    sensors.append(AlertLevelEntity(vigieau_coordinator, hass, entry, numeric_state=False))
-    sensors.append(AlertLevelEntity(vigieau_coordinator, hass, entry, numeric_state=True))
 
     async_add_entities(sensors)
-    await vigieau_coordinator.async_config_entry_first_refresh()

--- a/custom_components/vigieau/const.py
+++ b/custom_components/vigieau/const.py
@@ -50,6 +50,7 @@ class VigieEauRequiredKeysMixin:
 
     category: str
     matchers: list[str]
+    commonly_used: bool
 
 
 @dataclass
@@ -71,6 +72,7 @@ SENSOR_DEFINITIONS: tuple[VigieEauSensorEntityDescription, ...] = (
         icon="mdi:fountain",
         category="fountains",
         key="fountains",
+        commonly_used=True,
         matchers=[
 "Jeux d’eau.*Prélever",
             "Surfaces accueillant des manifestations temporaires sportives et culturelles.*Arroser",
@@ -87,6 +89,7 @@ SENSOR_DEFINITIONS: tuple[VigieEauSensorEntityDescription, ...] = (
         icon="mdi:watering-can",
         category="potagers",
         key="potagers",
+        commonly_used=True,
         matchers=[
             "Arrosage des .*potagers",
             "Prélèvement pour le lavage de fruits.*",
@@ -97,6 +100,7 @@ SENSOR_DEFINITIONS: tuple[VigieEauSensorEntityDescription, ...] = (
         icon="mdi:road",
         category="roads",
         key="roads",
+        commonly_used=False,
         matchers=[
             "Surfaces accueillant des manifestations temporaires.+sportives et culturelles.*Arroser",
             "trottoirs",
@@ -109,9 +113,10 @@ SENSOR_DEFINITIONS: tuple[VigieEauSensorEntityDescription, ...] = (
     ),
     VigieEauSensorEntityDescription(
         name="Arrosage des pelouses",
-        icon="mdi:sprinkler-variant",
+        icon="mdi:grass",
         category="lawn",
         key="lawn",
+        commonly_used=True,
         matchers=[
             "Arrosage des massifs arbustifs publics et privés.*Arroser",
             ".*pelouses.*",
@@ -147,6 +152,7 @@ SENSOR_DEFINITIONS: tuple[VigieEauSensorEntityDescription, ...] = (
         icon="mdi:car-wash",
         category="car_wash",
         key="car_wash",
+        commonly_used=True,
         matchers=[
 "Usagers d'un centre de lavage automobile.*Nettoyer",
 "Lavage automobile à domicile.*Nettoyer",
@@ -183,6 +189,7 @@ SENSOR_DEFINITIONS: tuple[VigieEauSensorEntityDescription, ...] = (
         icon="mdi:sail-boat",
         category="nautical_vehicules",
         key="nautical_vehicules",
+        commonly_used=False,
         matchers=[
 "Engins nautiques et matériel.*Nettoyer",
             ".*nautiques.*Travaux et activités en cours d'eau",
@@ -208,6 +215,7 @@ SENSOR_DEFINITIONS: tuple[VigieEauSensorEntityDescription, ...] = (
         icon="mdi:home-roof",
         category="roof_clean",
         key="roof_clean",
+        commonly_used=False,
         matchers=[
             "Nettoyage de terrasses.*Nettoyer",
             "Nettoyages des facades, murs, toits, terrasses et travaux.*Nettoyer",
@@ -226,6 +234,7 @@ SENSOR_DEFINITIONS: tuple[VigieEauSensorEntityDescription, ...] = (
         icon="mdi:pool",
         category="pool",
         key="pool",
+        commonly_used=True,
         matchers=[
 "Jeux d’eau.*Remplir ou vidanger",
 "ACI - Baignades artificielles en système fermé alimentées les ressources stockées.*Remplir ou vidanger",
@@ -259,6 +268,7 @@ SENSOR_DEFINITIONS: tuple[VigieEauSensorEntityDescription, ...] = (
         icon="mdi:waves",
         category="ponds",
         key="ponds",
+        commonly_used=False,
         matchers=[
 "Vidange de plan d’eau, d’étangs privés ou publics, bassins d’agrément.*Remplir ou vidanger",
 "Remplissage des  retenues de stockage en vue d’irrigation déconnectées de la ressource en eau.*Irriguer",
@@ -319,6 +329,7 @@ SENSOR_DEFINITIONS: tuple[VigieEauSensorEntityDescription, ...] = (
         icon="mdi:hydro-power",
         category="river_rate",
         key="river_rate",
+        commonly_used=False,
         matchers=[
 "prélèvement en nappe alluviale de la Loire.*Irriguer",
 "Prélèvement pour alimenter le canal de Berry.*Prélever",
@@ -405,6 +416,7 @@ SENSOR_DEFINITIONS: tuple[VigieEauSensorEntityDescription, ...] = (
         icon="mdi:ferry",
         category="river_movement",
         key="river_movement",
+        commonly_used=False,
         matchers=[
             "navigation fluviale sur le bassin Seine Normandie.*Travaux et activités en cours d'eau",
             "navigation fluviale sur le bassin Loire Bretagne.*Travaux et activités en cours d'eau",
@@ -418,6 +430,7 @@ SENSOR_DEFINITIONS: tuple[VigieEauSensorEntityDescription, ...] = (
         icon="mdi:golf",
         category="golfs",
         key="golfs",
+        commonly_used=False,
         matchers=[
 "Golfs et terrains de sports hippodromes et terrain en terre battue.*Arroser",
             "arrosage des golfs",
@@ -432,6 +445,7 @@ SENSOR_DEFINITIONS: tuple[VigieEauSensorEntityDescription, ...] = (
         icon="mdi:water-pump",
         category="canals",
         key="canals",
+        commonly_used=False,
         matchers=[
 "Prélèvements d’eau à usage domestique directement réalisés dans les cours d’eau.*Prélever",
 "Prélèvement individuel ou collectif.*Irriguer",
@@ -469,6 +483,7 @@ SENSOR_DEFINITIONS: tuple[VigieEauSensorEntityDescription, ...] = (
         icon="mdi:tree",
         category="trees",
         key="trees",
+        commonly_used=False,
         matchers=[
 "Arrosage de plantes et de fleurs des jardineries, des fleuristes, des pépiniéristes.*Arroser",
             "Cultures en godets et semis.*Arroser",
@@ -502,6 +517,7 @@ SENSOR_DEFINITIONS: tuple[VigieEauSensorEntityDescription, ...] = (
         icon="mdi:cow",
         category="animals",
         key="animals",
+        commonly_used=False,
         matchers=[
 "Hygiène de l’élevage et abreuvement du bétail.*Abreuver",
             "Arrosage des pistes pour chevaux.*Arroser",
@@ -515,6 +531,7 @@ SENSOR_DEFINITIONS: tuple[VigieEauSensorEntityDescription, ...] = (
         icon="mdi:corn",
         category="fields",
         key="fields",
+        commonly_used=False,
         matchers=[
 "Irrigation à partir d'eaux souterraines profondes.*Irriguer",
 "Irrigation localisée.*des cultures",
@@ -573,6 +590,7 @@ SENSOR_DEFINITIONS: tuple[VigieEauSensorEntityDescription, ...] = (
         name="Restriction spécifique",
         category="misc",
         key="misc",
+        commonly_used=False,
         matchers=[
             "Usages prioritaires liés à la santé, à la salubrité et à la sécurité civile.*",
             "Fonctionnement d'une pompe à chaleur pour usage non familial.*Installations de production d'électricité",

--- a/custom_components/vigieau/tests/test_time_based.py
+++ b/custom_components/vigieau/tests/test_time_based.py
@@ -1,0 +1,280 @@
+from os import path
+import sys
+from unittest.mock import MagicMock, patch
+from datetime import time as dt_time, datetime as dt_datetime, timedelta
+
+current_dir = path.dirname(__file__)
+parent_dir = path.dirname(current_dir)
+sys.path.append(".")
+sys.path.append(parent_dir)
+
+from custom_components.vigieau.__init__ import _parse_time_str, UsageRestrictionEntity, UsageRestrictionBinaryEntity
+import unittest
+
+
+class TestParseTimeStr(unittest.TestCase):
+    def test_parse_hhmm_colon(self):
+        self.assertEqual(_parse_time_str("08:00"), dt_time(8, 0))
+        self.assertEqual(_parse_time_str("20:00"), dt_time(20, 0))
+        self.assertEqual(_parse_time_str("8:00"), dt_time(8, 0))
+
+    def test_parse_hhmm_h_format(self):
+        self.assertEqual(_parse_time_str("8h00"), dt_time(8, 0))
+        self.assertEqual(_parse_time_str("20h00"), dt_time(20, 0))
+
+    def test_parse_hh_h_format(self):
+        self.assertEqual(_parse_time_str("8h"), dt_time(8, 0))
+        self.assertEqual(_parse_time_str("20h"), dt_time(20, 0))
+
+    def test_parse_none_or_empty(self):
+        self.assertIsNone(_parse_time_str(None))
+        self.assertIsNone(_parse_time_str(""))
+
+    def test_parse_invalid(self):
+        self.assertIsNone(_parse_time_str("abc"))
+
+
+class TestComputeNativeValue(unittest.TestCase):
+    def _make_entity(self, restrictions, time_restrictions=None, attributes=None):
+        entity = MagicMock(spec=UsageRestrictionEntity)
+        entity._restrictions = restrictions
+        entity._time_restrictions = time_restrictions or {}
+        entity._extracted_time_range = None
+        entity._attr_state_attributes = attributes or {}
+        entity._native_is_time_based = False
+        entity._config_entry = MagicMock()
+        entity._config_entry.data = {"INSEE": "99999"}
+        entity._attr_native_value = None
+
+        entity.compute_native_value = UsageRestrictionEntity.compute_native_value.__get__(entity, UsageRestrictionEntity)
+        entity._is_time_based = UsageRestrictionEntity._is_time_based.__get__(entity, UsageRestrictionEntity)
+        entity._extract_time_range_from_descriptions = UsageRestrictionEntity._extract_time_range_from_descriptions.__get__(entity, UsageRestrictionEntity)
+        return entity
+
+    def test_no_restrictions(self):
+        entity = self._make_entity([])
+        self.assertEqual(entity.compute_native_value(), "Aucune restriction")
+        self.assertFalse(entity._is_time_based())
+
+    def test_time_based_sur_plage_horaire(self):
+        entity = self._make_entity(["Interdiction sur plage horaire"])
+        result = entity.compute_native_value()
+        self.assertEqual(result, "Interdiction sur plage horaire")
+        self.assertTrue(entity._is_time_based())
+
+    def test_time_based_de_8h_a_20h_stable_native(self):
+        """Native value stays 'Interdiction sur plage horaire'; dynamic info is in attributes"""
+        entity = self._make_entity(
+            ["Interdiction de 8 h à 20 h"],
+            {"Arrosage potager": ["8h", "20h"]},
+            {"Categorie: Arrosage potager": "Interdiction de 8 h à 20 h"}
+        )
+        result = entity.compute_native_value()
+        self.assertEqual(result, "Interdiction sur plage horaire")
+        self.assertTrue(entity._is_time_based())
+
+    def test_time_based_no_time_data_fallback(self):
+        entity = self._make_entity(["Interdiction de 8 h à 20 h"])
+        result = entity.compute_native_value()
+        self.assertEqual(result, "Interdiction sur plage horaire")
+        self.assertTrue(entity._is_time_based())
+
+    def test_total_interdiction(self):
+        entity = self._make_entity(["Interdiction"])
+        result = entity.compute_native_value()
+        self.assertEqual(result, "Interdiction")
+        self.assertFalse(entity._is_time_based())
+
+    def test_mixed_time_and_total_interdiction(self):
+        entity = self._make_entity(["Interdiction de 8 h à 20 h", "Interdiction"])
+        result = entity.compute_native_value()
+        self.assertEqual(result, "Interdiction")
+        self.assertFalse(entity._is_time_based())
+
+    def test_interdiction_sauf_exception(self):
+        entity = self._make_entity(["Interdiction sauf exception"])
+        result = entity.compute_native_value()
+        self.assertEqual(result, "Interdiction sauf exception")
+        self.assertFalse(entity._is_time_based())
+
+    def test_autorise_sauf_exception(self):
+        entity = self._make_entity(["Pas de restriction sauf arrêté spécifique."])
+        result = entity.compute_native_value()
+        self.assertEqual(result, "Autorisé sauf exception")
+        self.assertFalse(entity._is_time_based())
+
+    def test_single_restriction_fallback(self):
+        entity = self._make_entity(["Réduction de prélèvement"])
+        result = entity.compute_native_value()
+        self.assertEqual(result, "Réduction de prélèvement")
+        self.assertFalse(entity._is_time_based())
+
+
+class TestExtractTimeRange(unittest.TestCase):
+    def _make_entity(self, restrictions):
+        entity = MagicMock(spec=UsageRestrictionEntity)
+        entity._restrictions = restrictions
+        entity._extract_time_range_from_descriptions = UsageRestrictionEntity._extract_time_range_from_descriptions.__get__(entity, UsageRestrictionEntity)
+        return entity
+
+    def test_extract_simple(self):
+        entity = self._make_entity(["Interdiction de 11h à 18h."])
+        result = entity._extract_time_range_from_descriptions()
+        self.assertIsNotNone(result)
+        start, end = result
+        self.assertEqual(start, dt_time(11, 0))
+        self.assertEqual(end, dt_time(18, 0))
+
+    def test_extract_with_spaces(self):
+        entity = self._make_entity(["Interdiction de 8 h à 20 h"])
+        result = entity._extract_time_range_from_descriptions()
+        self.assertIsNotNone(result)
+        start, end = result
+        self.assertEqual(start, dt_time(8, 0))
+        self.assertEqual(end, dt_time(20, 0))
+
+    def test_extract_no_match(self):
+        entity = self._make_entity(["Interdiction"])
+        self.assertIsNone(entity._extract_time_range_from_descriptions())
+
+
+class TestTimeAttributes(unittest.TestCase):
+    def _make_entity(self, restrictions, time_restrictions=None, extracted_range=None):
+        entity = MagicMock(spec=UsageRestrictionEntity)
+        entity._restrictions = restrictions
+        entity._time_restrictions = time_restrictions or {}
+        entity._extracted_time_range = extracted_range
+        entity._attr_state_attributes = {}
+
+        entity._get_effective_time_ranges = UsageRestrictionEntity._get_effective_time_ranges.__get__(entity, UsageRestrictionEntity)
+        entity._is_currently_restricted = UsageRestrictionEntity._is_currently_restricted.__get__(entity, UsageRestrictionEntity)
+        entity._update_dynamic_attributes = UsageRestrictionEntity._update_dynamic_attributes.__get__(entity, UsageRestrictionEntity)
+        entity._native_is_time_based = False
+        entity._attr_native_value = None
+        return entity
+
+    def test_get_ranges_from_api(self):
+        entity = self._make_entity([], {"u1": ["8h", "20h"]})
+        ranges = entity._get_effective_time_ranges()
+        self.assertEqual(len(ranges), 1)
+        self.assertEqual(ranges[0], (dt_time(8, 0), dt_time(20, 0)))
+
+    def test_get_ranges_from_extracted(self):
+        entity = self._make_entity([], extracted_range=(dt_time(11, 0), dt_time(18, 0)))
+        ranges = entity._get_effective_time_ranges()
+        self.assertEqual(len(ranges), 1)
+        self.assertEqual(ranges[0], (dt_time(11, 0), dt_time(18, 0)))
+
+    def test_get_ranges_empty(self):
+        entity = self._make_entity([])
+        self.assertEqual(entity._get_effective_time_ranges(), [])
+
+    def test_currently_restricted_inside(self):
+        entity = self._make_entity([], extracted_range=(dt_time(8, 0), dt_time(20, 0)))
+        self.assertTrue(entity._is_currently_restricted(dt_time(10, 0)))
+
+    def test_currently_restricted_outside(self):
+        entity = self._make_entity([], extracted_range=(dt_time(8, 0), dt_time(20, 0)))
+        self.assertFalse(entity._is_currently_restricted(dt_time(22, 0)))
+
+    def test_currently_restricted_overnight_inside(self):
+        entity = self._make_entity([], extracted_range=(dt_time(20, 0), dt_time(8, 0)))
+        self.assertTrue(entity._is_currently_restricted(dt_time(22, 0)))
+
+    def test_currently_restricted_overnight_outside(self):
+        entity = self._make_entity([], extracted_range=(dt_time(20, 0), dt_time(8, 0)))
+        self.assertFalse(entity._is_currently_restricted(dt_time(12, 0)))
+
+    def test_dynamic_attributes_total_interdiction(self):
+        """Total ban should have currently_restricted=True, no time attributes"""
+        entity = self._make_entity(["Interdiction"])
+        entity._native_is_time_based = False
+        entity._attr_state_attributes = {"restriction": "Interdiction"}
+        entity._update_dynamic_attributes()
+        self.assertTrue(entity._attr_state_attributes["currently_restricted"])
+        self.assertNotIn("next_restriction_start", entity._attr_state_attributes)
+        self.assertNotIn("next_restriction_end", entity._attr_state_attributes)
+
+    def test_dynamic_attributes_aucune_restriction(self):
+        entity = self._make_entity([])
+        entity._native_is_time_based = False
+        entity._attr_state_attributes = {"restriction": "Aucune restriction"}
+        entity._update_dynamic_attributes()
+        self.assertFalse(entity._attr_state_attributes["currently_restricted"])
+        self.assertNotIn("next_restriction_start", entity._attr_state_attributes)
+
+    def test_dynamic_attributes_autorise_sauf_exception(self):
+        entity = self._make_entity(["Pas de restriction sauf arrêté spécifique."])
+        entity._native_is_time_based = False
+        entity._attr_state_attributes = {"restriction": "Autorisé sauf exception"}
+        entity._update_dynamic_attributes()
+        self.assertFalse(entity._attr_state_attributes["currently_restricted"])
+
+    def test_dynamic_attributes_time_based_restricted(self):
+        """Time-based at 14h for 11h-18h: currently_restricted=True, with time attributes"""
+        entity = self._make_entity(
+            ["Interdiction de 11h à 18h"],
+            extracted_range=(dt_time(11, 0), dt_time(18, 0))
+        )
+        entity._native_is_time_based = True
+        entity._attr_state_attributes = {"restriction": "Interdiction sur plage horaire"}
+        fake_now = dt_datetime(2026, 7, 6, 14, 0, 0)
+        with patch('custom_components.vigieau.__init__.datetime') as mock_dt:
+            mock_dt.now.return_value = fake_now
+            mock_dt.time = dt_datetime.time
+            entity._update_dynamic_attributes()
+        self.assertTrue(entity._attr_state_attributes["currently_restricted"])
+        self.assertIn("next_restriction_start", entity._attr_state_attributes)
+        self.assertIn("next_restriction_end", entity._attr_state_attributes)
+
+    def test_dynamic_attributes_time_based_not_restricted(self):
+        """Time-based at 22h for 11h-18h: currently_restricted=False, with time attributes"""
+        entity = self._make_entity(
+            ["Interdiction de 11h à 18h"],
+            extracted_range=(dt_time(11, 0), dt_time(18, 0))
+        )
+        entity._native_is_time_based = True
+        entity._attr_state_attributes = {"restriction": "Interdiction sur plage horaire"}
+        fake_now = dt_datetime(2026, 7, 6, 22, 0, 0)
+        with patch('custom_components.vigieau.__init__.datetime') as mock_dt:
+            mock_dt.now.return_value = fake_now
+            mock_dt.time = dt_datetime.time
+            entity._update_dynamic_attributes()
+        self.assertFalse(entity._attr_state_attributes["currently_restricted"])
+        self.assertIn("next_restriction_start", entity._attr_state_attributes)
+        self.assertIn("next_restriction_end", entity._attr_state_attributes)
+
+
+class TestBinarySensorEntity(unittest.TestCase):
+    def _make_binary_entity(self, state_attributes=None):
+        entity = MagicMock(spec=UsageRestrictionBinaryEntity)
+        entity._attr_state_attributes = state_attributes or {}
+        entity._config = MagicMock()
+        entity._config.commonly_used = False
+        entity.is_on = UsageRestrictionBinaryEntity.is_on.__get__(entity, UsageRestrictionBinaryEntity)
+        entity.icon = UsageRestrictionBinaryEntity.icon.__get__(entity, UsageRestrictionBinaryEntity)
+        return entity
+
+    def test_is_on_when_restricted(self):
+        entity = self._make_binary_entity({"currently_restricted": True})
+        self.assertFalse(entity.is_on)
+
+    def test_is_on_when_not_restricted(self):
+        entity = self._make_binary_entity({"currently_restricted": False})
+        self.assertTrue(entity.is_on)
+
+    def test_is_on_when_no_attrs(self):
+        entity = self._make_binary_entity(None)
+        self.assertTrue(entity.is_on)
+
+    def test_icon_restricted(self):
+        entity = self._make_binary_entity({"currently_restricted": True})
+        self.assertEqual(entity.icon, "mdi:water-off")
+
+    def test_icon_not_restricted(self):
+        entity = self._make_binary_entity({"currently_restricted": False})
+        self.assertEqual(entity.icon, "mdi:water-check")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
…restriction handling

- Each usage now has a string sensor and a binary sensor (on=allowed)
- Binary sensors enabled by default for fountains, vegetable gardens, lawns, car washes, and swimming pools
- String sensors disabled by default
- New attributes for automations: currently_restricted, next_restriction_start, next_restriction_end
- Broaden time-based detection to catch patterns like "Interdiction de 8 h à 20 h"
- Fallback: extract hours from description text when API does not provide them Fixes #112