### PR TITLE
Fix #115: exclude (hors ...) clauses from matchers and improve time-based detection

### DIFF
--- a/custom_components/vigieau/__init__.py
+++ b/custom_components/vigieau/__init__.py
@@ -449,7 +449,7 @@ class RestrictionMixin:
                     return True
             return False
 
-        TIME_PATTERNS = [r"interdiction sur plage horaire", r"interdiction.*\d+\s*h"]
+        TIME_PATTERNS = [r"interdiction sur plage horaire", r"(?:interdiction|interdit).*\d+\s*h"]
 
         def has_time_based_interdiction():
             for pattern in TIME_PATTERNS:
@@ -531,6 +531,10 @@ class RestrictionMixin:
                 start_time = _parse_time_str(start_str)
                 end_time = _parse_time_str(end_str)
                 if start_time is not None and end_time is not None:
+                    # "uniquement de X h à Y h" describes the ALLOWED window.
+                    # We need the RESTRICTED window, so swap start and end.
+                    if re.search(r"uniquement\s+de\s+\d", restriction, re.IGNORECASE):
+                        start_time, end_time = end_time, start_time
                     _LOGGER.debug(
                         f"Extracted time range {start_time}-{end_time} from description: {restriction}"
                     )

--- a/custom_components/vigieau/const.py
+++ b/custom_components/vigieau/const.py
@@ -61,7 +61,13 @@ class VigieEauSensorEntityDescription(
 
     def match(self, usage: dict) -> bool:
         for matcher in self.matchers:
-            if re.search(matcher, usage["nom"] + "|" + usage["thematique"]):
+            nom = usage["nom"]
+            # Strip parenthesized exclusion clauses ("(hors ...)") before
+            # matching, unless the matcher itself contains "hors" (meaning
+            # it intentionally targets text with that keyword).
+            if "hors" not in matcher.lower():
+                nom = re.sub(r"\(hors[^)]*\)", "", nom)
+            if re.search(matcher, nom + "|" + usage["thematique"]):
                 return True
         return False
 
@@ -91,9 +97,10 @@ SENSOR_DEFINITIONS: tuple[VigieEauSensorEntityDescription, ...] = (
         key="potagers",
         commonly_used=True,
         matchers=[
-"Prélèvement d’eau pour l’irrigation par système ‍d’irrigation localisée (goutte à gouttes, micro-aspersion) (hors périmètres irrigués).*Prélever",
+            "Prélèvement d’eau pour l’irrigation par système ‍d’irrigation localisée \(goutte à gouttes, micro-aspersion\) \(hors périmètres irrigués\).*Prélever",
             "Arrosage des .*potagers",
             "Prélèvement pour le lavage de fruits.*",
+            "plants destinés à l'alimentation",
         ],
     ),
     VigieEauSensorEntityDescription(

--- a/custom_components/vigieau/tests/test_regexp.py
+++ b/custom_components/vigieau/tests/test_regexp.py
@@ -34,6 +34,106 @@ class TestRegexp(unittest.TestCase):
                     f"Value **{restriction['usage']}** in category **{restriction['thematique']}** not found in matcher",
                 )  # Check for one usage if it has been found
 
+    def test_hors_exclusion_stripped_for_potagers(self):
+        """Usages with '(hors ... jardins potagers)' must NOT match the potagers sensor."""
+        potagers_sensor = None
+        for s in SENSOR_DEFINITIONS:
+            if s.name == "Arrosage des jardins potagers":
+                potagers_sensor = s
+                break
+        self.assertIsNotNone(potagers_sensor)
+
+        usage = {
+            "nom": "Arrosage des espaces verts (hors pelouses, fleurs et massifs fleuris ainsi que jardins potagers)",
+            "thematique": "Arroser",
+        }
+        self.assertFalse(
+            potagers_sensor.match(usage),
+            "Usage with '(hors ... jardins potagers)' should NOT match potagers sensor",
+        )
+
+    def test_potagers_still_matches(self):
+        """Genuine potager usages must still match the potagers sensor."""
+        potagers_sensor = None
+        for s in SENSOR_DEFINITIONS:
+            if s.name == "Arrosage des jardins potagers":
+                potagers_sensor = s
+                break
+        self.assertIsNotNone(potagers_sensor)
+
+        for nom in [
+            "Arrosage des jardins potagers",
+            "Arrosage des potagers",
+            "Arrosage des jardins potagers (y compris serres non-agricoles)",
+        ]:
+            with self.subTest(nom=nom):
+                self.assertTrue(
+                    potagers_sensor.match({"nom": nom, "thematique": "Arroser"}),
+                    f"'{nom}' should match potagers sensor",
+                )
+
+    def test_hors_exclusion_does_not_affect_matchers_with_hors(self):
+        """Matchers that contain 'hors' in their pattern must still match with full names."""
+        file = os.path.join(parent_dir, "scripts/full_usage_list.json")
+        with open(file) as f:
+            data = json.loads(f.read())
+
+        matched_restrictions = []
+        for restriction in data["restrictions"]:
+            restriction["nom"] = restriction["usage"]
+            if "hors périmètres irrigués" in restriction["usage"]:
+                matched_restrictions.append(restriction)
+                found = False
+                for sensor in SENSOR_DEFINITIONS:
+                    if sensor.match(restriction):
+                        found = True
+                        break
+                self.assertTrue(
+                    found,
+                    f"'{restriction['usage']}' should match at least one sensor "
+                    f"(matcher with 'hors' should use full name)",
+                )
+        self.assertGreater(
+            len(matched_restrictions), 0,
+            "No restriction with 'hors périmètres irrigués' found in test data",
+        )
+
+    def test_hors_exclusion_reclassifies_out_of_maraichage(self):
+        """Usage with '(hors usage agricole)' must NOT match Maraîchage et cultures."""
+        maraichage_sensor = None
+        for s in SENSOR_DEFINITIONS:
+            if s.name == "Maraîchage et cultures":
+                maraichage_sensor = s
+                break
+        self.assertIsNotNone(maraichage_sensor)
+
+        usage = {
+            "nom": "Arrosage des plants destinés à l'alimentation (hors usage agricole)",
+            "thematique": "Arroser",
+        }
+        self.assertFalse(
+            maraichage_sensor.match(usage),
+            "Usage with '(hors usage agricole)' should NOT match Maraîchage et cultures",
+        )
+
+    def test_hors_exclusion_potager_reclassified_to_potagers(self):
+        """Usage '(hors usage agricole)' reclassified should match potagers."""
+        potagers_sensor = None
+        for s in SENSOR_DEFINITIONS:
+            if s.name == "Arrosage des jardins potagers":
+                potagers_sensor = s
+                break
+        self.assertIsNotNone(potagers_sensor)
+
+        usage = {
+            "nom": "Arrosage des plants destinés à l'alimentation (hors usage agricole)",
+            "thematique": "Arroser",
+        }
+        self.assertTrue(
+            potagers_sensor.match(usage),
+            "Usage 'plants destinés à l\\'alimentation (hors usage agricole)' should match potagers",
+        )
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/custom_components/vigieau/tests/test_time_based.py
+++ b/custom_components/vigieau/tests/test_time_based.py
@@ -79,6 +79,15 @@ class TestComputeNativeValue(unittest.TestCase):
         self.assertEqual(result, "Interdiction sur plage horaire")
         self.assertTrue(entity._is_time_based())
 
+    def test_time_based_interdit_with_time_pattern(self):
+        """'Interdit' (not 'Interdiction') with a time pattern should be detected as time-based."""
+        entity = self._make_entity(
+            ["Interdit sauf plantations (arbres) et îlots de fraîcheur uniquement de 20 h à 8 h"]
+        )
+        result = entity.compute_native_value()
+        self.assertEqual(result, "Interdiction sur plage horaire")
+        self.assertTrue(entity._is_time_based())
+
     def test_total_interdiction(self):
         entity = self._make_entity(["Interdiction"])
         result = entity.compute_native_value()
@@ -136,6 +145,27 @@ class TestExtractTimeRange(unittest.TestCase):
     def test_extract_no_match(self):
         entity = self._make_entity(["Interdiction"])
         self.assertIsNone(entity._extract_time_range_from_descriptions())
+
+    def test_extract_interdit_sauf_uniquement_de_inverts_range(self):
+        """'uniquement de X h à Y h' describes the allowed window, so the
+        extracted restricted window should be the complement (Y-X)."""
+        entity = self._make_entity(
+            ["Interdit sauf plantations (arbres) et îlots de fraîcheur uniquement de 20 h à 8 h"]
+        )
+        result = entity._extract_time_range_from_descriptions()
+        self.assertIsNotNone(result)
+        start, end = result
+        self.assertEqual(start, dt_time(8, 0))
+        self.assertEqual(end, dt_time(20, 0))
+
+    def test_extract_interdit_sauf_uniquement_de_does_not_affect_normal(self):
+        """Normal patterns like 'de X h à Y h' are not affected by the uniquement fix."""
+        entity = self._make_entity(["Interdiction de 11h à 18h."])
+        result = entity._extract_time_range_from_descriptions()
+        self.assertIsNotNone(result)
+        start, end = result
+        self.assertEqual(start, dt_time(11, 0))
+        self.assertEqual(end, dt_time(18, 0))
 
 
 class TestTimeAttributes(unittest.TestCase):


### PR DESCRIPTION

- Strip parenthesized exclusion clauses (hors ...) before matching, unless the matcher itself contains 'hors' (meaning it intentionally targets that keyword).
- Add matcher 'plants destinés à l'alimentation' for usages previously falsely matched by 'Maraîchage et cultures' via 'agricole'.
- Escape unescaped parentheses in potagers matcher (bug préexistant).
- Extend TIME_PATTERNS to detect 'Interdit' (not just 'Interdiction').
- Invert extracted time range when description says 'uniquement de X h à Y h' (allowed window, not restricted).
- Add 8 new tests covering both fixes.