### PR TITLE
Fix #118: use restriction text as fallback when all restrictions are identical

### DIFF
--- a/custom_components/vigieau/__init__.py
+++ b/custom_components/vigieau/__init__.py
@@ -508,7 +508,7 @@ class RestrictionMixin:
             return "Sensibilisation"
         if any_restriction_match("Réduction"):
             return "Réduction"
-        if len(self._restrictions) == 1:
+        if len(set(self._restrictions)) == 1:
             return self._restrictions[0]
         report_data = json.dumps(
             {"insee code": self._config_entry.data.get(CONF_INSEE_CODE), "restrictions": self._restrictions},

--- a/custom_components/vigieau/tests/test_time_based.py
+++ b/custom_components/vigieau/tests/test_time_based.py
@@ -118,6 +118,14 @@ class TestComputeNativeValue(unittest.TestCase):
         self.assertEqual(result, "Réduction de prélèvement")
         self.assertFalse(entity._is_time_based())
 
+    def test_identical_duplicate_restrictions_fallback(self):
+        entity = self._make_entity(
+            ["Information via communiqué de presse", "Information via communiqué de presse", "Information via communiqué de presse"]
+        )
+        result = entity.compute_native_value()
+        self.assertEqual(result, "Information via communiqué de presse")
+        self.assertFalse(entity._is_time_based())
+
 
 class TestExtractTimeRange(unittest.TestCase):
     def _make_entity(self, restrictions):


### PR DESCRIPTION
When multiple identical restrictions (e.g. 'Information via communiqué de presse' repeated 3x) are returned by the API but none match known patterns, treat them as a single entry with that text instead of falling through to unknown.

Fixes #118
